### PR TITLE
Refactor: remove "duplicate" editor view constants from XMLimport class

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -22,6 +22,8 @@
 
 #include "XMLimport.h"
 
+
+#include "dlgTriggerEditor.h"
 #include "LuaInterface.h"
 #include "TAction.h"
 #include "TAlias.h"
@@ -45,14 +47,6 @@
 // clang-format: off
 #include "post_guard.h"
 // clang-format: on
-
-const int XMLimport::cmTriggerView = 1;
-const int XMLimport::cmTimerView = 2;
-const int XMLimport::cmAliasView = 3;
-const int XMLimport::cmScriptView = 4;
-const int XMLimport::cmActionView = 5;
-const int XMLimport::cmKeysView = 6;
-const int XMLimport::cmVarsView = 7;
 
 XMLimport::XMLimport(Host* pH)
     : mpHost(pH)
@@ -542,27 +536,27 @@ int XMLimport::readPackage()
             if (name() == "HostPackage") {
                 readHostPackage();
             } else if (name() == "TriggerPackage") {
-                objectType = cmTriggerView;
+                objectType = dlgTriggerEditor::cmTriggerView;
                 readTriggerPackage();
             } else if (name() == "TimerPackage") {
-                objectType = cmTimerView;
+                objectType = dlgTriggerEditor::cmTimerView;
                 readTimerPackage();
             } else if (name() == "AliasPackage") {
-                objectType = cmAliasView;
+                objectType = dlgTriggerEditor::cmAliasView;
                 readAliasPackage();
             } else if (name() == "ActionPackage") {
-                objectType = cmActionView;
+                objectType = dlgTriggerEditor::cmActionView;
                 readActionPackage();
             } else if (name() == "ScriptPackage") {
-                objectType = cmScriptView;
+                objectType = dlgTriggerEditor::cmScriptView;
                 readScriptPackage();
             } else if (name() == "KeyPackage") {
-                objectType = cmKeysView;
+                objectType = dlgTriggerEditor::cmKeysView;
                 readKeyPackage();
             } else if (name() == "HelpPackage") {
                 readHelpPackage();
             } else if (name() == "VariablePackage") {
-                objectType = cmVarsView;
+                objectType = dlgTriggerEditor::cmVarsView;
                 readVariablePackage();
             } else {
                 readUnknownPackage();

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -118,14 +118,6 @@ private:
     int module;
     int mMaxRoomId;
     int mMaxAreaId; // Could be useful when iterating through map data
-
-    static const int            cmTriggerView;
-    static const int            cmTimerView;
-    static const int            cmAliasView;
-    static const int            cmScriptView;
-    static const int            cmActionView;
-    static const int            cmKeysView;
-    static const int            cmVarsView;
 };
 
 #endif // MUDLET_XMLEXPORT_H

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -104,6 +104,15 @@ public:
     void                        show_vars( );
 
 
+    static const int            cmTriggerView;
+    static const int            cmTimerView;
+    static const int            cmAliasView;
+    static const int            cmScriptView;
+    static const int            cmActionView;
+    static const int            cmKeysView;
+    static const int            cmVarsView;
+
+
 public slots:
     void                        slot_toggleHiddenVariables( bool );
     void                        slot_toggleHiddenVar( bool );
@@ -251,13 +260,6 @@ private:
     QTreeWidgetItem *           mpCurrentVarItem;
     QLineEdit *                 mpCursorPositionIndicator;
     int                         mCurrentView;
-    static const int            cmTriggerView;
-    static const int            cmTimerView;
-    static const int            cmAliasView;
-    static const int            cmScriptView;
-    static const int            cmActionView;
-    static const int            cmKeysView;
-    static const int            cmVarsView;
 
     QScrollArea *               mpScrollArea;
     QWidget *                   HpatternList;


### PR DESCRIPTION
It is not wise to duplicate a set of coded values when it is possible to use the originals - this makes it safer should anything change to the latter.  It does need to make the values `public` from the class where they are defined but as they are `static const`ants this should be safe to do.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>